### PR TITLE
simplify the check and make the naming scheme configurable

### DIFF
--- a/bin/metrics-pdns.rb
+++ b/bin/metrics-pdns.rb
@@ -1,10 +1,9 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 #
-# <metrics-pdns.rb>
+# metrics-pdns.rb
 #
 # DESCRIPTION:
-# simple ruby script to extract PowerDNS recursor statistics and send them in Graphite PlainText format
-
+#   Extract PowerDNS recursor statistics and send them in Graphite plaintext format
 #
 # OUTPUT:
 #   plain text metric data
@@ -16,8 +15,10 @@
 #   gem: sensu-plugin
 #
 # USAGE:
+#   metrics-pdns.rb
 #
 # NOTES:
+#   Requires sudo permissions for the sensu user to run rec_control
 #
 # LICENSE:
 #   <Hammad Shah>  <haashah@gmail.com>
@@ -28,36 +29,23 @@
 require 'sensu-plugin'
 require 'sensu-plugin/metric/cli'
 require 'English'
+require 'socket'
 
 class PdnsGraphite < Sensu::Plugin::Metric::CLI::Graphite
-  option :dump_file,
-         description: 'name of file to dump powerDNS stats to',
-         short: '-d DUMPFILE',
-         long: '--dump DUMPFILE',
-         default: 'tmp.txt'
-
-  def output(*args)
-    return unless args.empty?
-    args[2] = Time.now.to_is if args[2].nil?
-    puts "#{`hostname -f`.chomp}-- #{args[0..2].join('\s')}"
-  end
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}.pdns"
 
   def run
-    # dump powerdns statistics using rec control
-    # TODO: @haashah only extract user specified metrics.
-    system "sudo rec_control get-all > /tmp/#{config[:dump_file]}"
+    metrics = `sudo rec_control get-all`.split("\n")
     if $CHILD_STATUS.exitstatus > 0
-      puts 'failed to dump pdns statistics. check pdns process is running!'
-      exit 2
+      critical 'Failed to dump pdns statistics. Check that the pdns process is running!'
     end
-    File.readlines("/tmp/#{config[:dump_file]}").each do |line|
-      output line.split[0], line.split[1]
+    metrics.each do |metric|
+      (key, value) = metric.split("\t")
+      output([config[:scheme], key].join('.'), value)
     end
-  end
-
-  def teardown
-    # time to cleanup dump file
-    system "sudo rm -rf /tmp/#{config[:dump_file]}"
-    exit 2 if $CHILD_STATUS.exitstatus > 0
+    ok
   end
 end

--- a/test/metrics_pdns_spec.rb
+++ b/test/metrics_pdns_spec.rb
@@ -5,16 +5,13 @@ describe 'PdnsGraphite', '#run' do
     PdnsGraphite.class_variable_set(:@@autorun, nil)
     @metrics = PdnsGraphite.new
   end
-  context 'when no argument passed' do
-    it 'it dumps tmp.txt' do
+
+  it 'returns ok' do
+    begin
       @metrics.run
-      expect(File).to exist('/tmp/tmp.txt')
+    rescue SystemExit => e
+      exit_code = e.status
     end
-  end
-  context 'when teardown called' do
-    it 'cleans up properly' do
-      @metrics.teardown
-      expect(File).not_to exist('/tmp/tmp.txt')
-    end
+    expect(exit_code).to eq 0
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

Simplification and cleanup of this check.

1. Make the metrics naming scheme configurable with the `--scheme` flag. This makes it consistent with other metrics checks.
2. Take the metrics directly from the `rec_control` command vs writing to a file to avoid unnecessary file IO. 
3. Use the `critical` and `ok` methods from `sensu-plugin` instead of using `puts` and `exit`.
5. Expand the header with usage information.

Example output:

```
40e53bb84786.pdns.all-outqueries 28 1503643768
40e53bb84786.pdns.answers-slow 0 1503643768
40e53bb84786.pdns.answers0-1 0 1503643768
40e53bb84786.pdns.answers1-10 0 1503643768
40e53bb84786.pdns.answers10-100 0 1503643768
40e53bb84786.pdns.answers100-1000 2 1503643768
40e53bb84786.pdns.auth4-answers-slow 0 1503643768
...
```